### PR TITLE
RavenDB hook for MiniProfiler

### DIFF
--- a/Raven.Client.Contrib/Profiling/JsonFormatter.cs
+++ b/Raven.Client.Contrib/Profiling/JsonFormatter.cs
@@ -1,0 +1,95 @@
+using System;
+using System.Collections.Generic;
+using System.Linq;
+using System.Text;
+using Raven.Client.Connection.Profiling;
+using Raven.Imports.Newtonsoft.Json;
+using Raven.Imports.Newtonsoft.Json.Linq;
+using Raven.Json.Linq;
+
+namespace Raven.Client.Contrib.Profiling
+{
+    internal static class JsonFormatter
+    {
+        public static ProfilingInformation Format(ProfilingInformation information)
+        {
+            var profilingInformation                  = ProfilingInformation.CreateProfilingInformation(information.Id);
+            profilingInformation.At                   = information.At;
+            profilingInformation.Context              = information.Context;
+            profilingInformation.DurationMilliseconds = information.DurationMilliseconds;
+            profilingInformation.Requests             = information.Requests.Select(FormatRequest).ToList();
+
+            return profilingInformation;
+        }
+
+        public static RequestResultArgs FormatRequest(RequestResultArgs input)
+        {
+            return new RequestResultArgs
+            {
+                DurationMilliseconds = input.DurationMilliseconds,
+                At                   = input.At,
+                HttpResult           = input.HttpResult,
+                Method               = input.Method,
+                Status               = input.Status,
+                Url                  = input.Url,
+                PostedData           = FilterData(input.PostedData),
+                Result               = FilterData(input.Result)
+
+            };
+        }
+
+        private static string FilterData(string result)
+        {
+            RavenJToken token;
+
+            try
+            {
+                token = RavenJToken.Parse(result);
+            }
+            catch (Exception)
+            {
+                return result;
+            }
+
+            Visit(token);
+
+            return token.ToString(Formatting.Indented);
+        }
+
+        private static void Visit(RavenJToken token)
+        {
+            switch (token.Type)
+            {
+                case JTokenType.Object:
+                    foreach (var item in (RavenJObject)token)
+                        Visit(item.Value);
+
+                    break;
+
+                case JTokenType.Array:
+                    foreach (var items in (RavenJArray)token)
+                        Visit(items);
+
+                    break;
+
+                case JTokenType.Constructor:
+                case JTokenType.Property:
+                case JTokenType.Comment:
+                case JTokenType.None:
+                case JTokenType.Integer:
+                case JTokenType.Float:
+                case JTokenType.String:
+                case JTokenType.Boolean:
+                case JTokenType.Null:
+                case JTokenType.Undefined:
+                case JTokenType.Date:
+                case JTokenType.Raw:
+                case JTokenType.Bytes:
+                    break;
+
+                default:
+                    throw new ArgumentOutOfRangeException(token.Type.ToString());
+            }
+        }
+    }
+}

--- a/Raven.Client.Contrib/Profiling/RavenProfiler.cs
+++ b/Raven.Client.Contrib/Profiling/RavenProfiler.cs
@@ -1,0 +1,102 @@
+using System;
+using System.Collections.Generic;
+using System.Diagnostics;
+using System.Linq;
+using System.Reflection;
+using System.Text;
+using System.Text.RegularExpressions;
+using System.Web;
+using Raven.Client.Connection.Profiling;
+using Raven.Client.Document;
+using StackExchange.Profiling;
+using StackExchange.Profiling.Data;
+
+namespace Raven.Client.Contrib.Profiling
+{
+    public static class RavenProfiler
+    {
+        private static readonly MethodInfo ElapsedTicks;
+
+        static RavenProfiler()
+        {
+            ElapsedTicks = typeof(MiniProfiler).GetProperty("ElapsedTicks", BindingFlags.NonPublic | BindingFlags.Instance).GetGetMethod(nonPublic: true);
+        }
+
+        public static void InitializeFor(DocumentStore store)
+        {
+            if (store != null && store.JsonRequestFactory != null)
+                store.JsonRequestFactory.LogRequest += (sender, r) => IncludeTiming(JsonFormatter.FormatRequest(r));
+        }
+
+        private static void IncludeTiming(RequestResultArgs request)
+        {
+            if (MiniProfiler.Current == null)
+                return;
+
+            var elapsedTicks       = (long)ElapsedTicks.Invoke(MiniProfiler.Current, null);
+            var elapsedSeconds     = elapsedTicks / (double)Stopwatch.Frequency;
+            var profilingStartedAt = DateTime.UtcNow.AddSeconds(-elapsedSeconds);
+
+#pragma warning disable 612,618
+            var secs = (request.At - profilingStartedAt).TotalSeconds;
+            var timing = new SqlTiming // The default constructor is obsolete. We know about that; this is a hack anyway.
+            {
+                Id                             = Guid.NewGuid(),
+                CommandString                  = FormatQuery(request.Url),
+                StartMilliseconds              = (decimal)secs * 1000,
+                DurationMilliseconds           = (decimal)request.DurationMilliseconds,
+                FirstFetchDurationMilliseconds = (decimal)request.DurationMilliseconds,
+                ExecuteType                    = ToExecuteType(request.Status),
+            };
+#pragma warning restore 612,618
+
+            MiniProfiler.Current.Head.AddSqlTiming(timing);
+            MiniProfiler.Current.HasSqlTimings = true;
+        }
+
+        private static ExecuteType ToExecuteType(RequestStatus status)
+        {
+            switch (status)
+            {
+                case RequestStatus.ErrorOnServer:
+                    return ExecuteType.None;
+                    
+                case RequestStatus.Cached:
+                    return ExecuteType.Scalar;
+
+                case RequestStatus.SentToServer:
+                    return ExecuteType.Reader;
+
+                case RequestStatus.AggresivelyCached:
+                    return ExecuteType.NonQuery;
+
+                default:
+                    return ExecuteType.None;
+            }
+        }
+
+        private static string FormatQuery(string url)
+        {
+            var results = url.Split('?');
+
+			if (results.Length > 1)
+			{
+				string[] items = results[1].Split('&');
+                string query   = String.Join("\r\n", items).Trim();
+
+                var match = Regex.Match(results[0], @"/indexes/[A-Za-z/]+");
+                if (match.Success)
+                {
+                    string index = match.Value.Replace("/indexes/", "");
+
+                    if (!String.IsNullOrEmpty(index))
+                        query = String.Format("index={0}\r\n", index) + query;
+                }
+
+                return Uri.UnescapeDataString(Uri.UnescapeDataString(query));
+			}
+
+            return String.Empty;
+        }
+    }
+}

--- a/Raven.Client.Contrib/Raven.Client.Contrib.csproj
+++ b/Raven.Client.Contrib/Raven.Client.Contrib.csproj
@@ -34,6 +34,9 @@
   </PropertyGroup>
   <ItemGroup>
     <Reference Include="Microsoft.CSharp" />
+    <Reference Include="MiniProfiler">
+      <HintPath>..\packages\MiniProfiler.2.0.2\lib\net40\MiniProfiler.dll</HintPath>
+    </Reference>
     <Reference Include="Raven.Abstractions">
       <HintPath>..\packages\RavenDB.Client.2.0.2170-Unstable\lib\net40\Raven.Abstractions.dll</HintPath>
     </Reference>
@@ -50,6 +53,8 @@
     <Compile Include="Extensions\DocumentIdExtensions.cs" />
     <Compile Include="Extensions\PagingExtensions.cs" />
     <Compile Include="Extensions\TenantDatabaseExtensions.cs" />
+    <Compile Include="Profiling\JsonFormatter.cs" />
+    <Compile Include="Profiling\RavenProfiler.cs" />
     <Compile Include="Properties\AssemblyInfo.cs" />
     <Compile Include="Extensions\QueryExtensions.cs" />
   </ItemGroup>

--- a/Raven.Client.Contrib/packages.config
+++ b/Raven.Client.Contrib/packages.config
@@ -1,4 +1,5 @@
 ﻿<?xml version="1.0" encoding="utf-8"?>
 <packages>
+  <package id="MiniProfiler" version="2.0.2" targetFramework="net40" />
   <package id="RavenDB.Client" version="2.0.2170-Unstable" targetFramework="net40" />
 </packages>


### PR DESCRIPTION
It is not that elegant (queries show up as "sql", query types aren't... too helpful, etc.), but it gets the job done. Uses the JSON formatter from the RavenDB MVC profiler.

Just call RavenProfiler.InitializeFor(store) in your application startup, after you've initialized the store of course.
