### PR TITLE
Fix "multiple question marks" bug for UriBuilder.

### DIFF
--- a/src/Raven.Contrib.AspNet.Demo/Extensions/UriExtensions.cs
+++ b/src/Raven.Contrib.AspNet.Demo/Extensions/UriExtensions.cs
@@ -20,7 +20,7 @@ namespace Raven.Contrib.AspNet.Demo.Extensions
             string encodedValue = Uri.EscapeDataString(value);
             string queryString  = String.Format("{0}={1}", encodedKey, encodedValue);
 
-            builder.Query += String.IsNullOrEmpty(builder.Query) ? queryString : "&" + queryString;
+            builder.Query = String.IsNullOrEmpty(builder.Query) ? queryString : builder.Query.Substring(1) + "&" + queryString;
 
             return builder.Uri;
         }


### PR DESCRIPTION
I ran into this bug when calling AddQueryParameter multiple times. The second time around you end up with two question marks because of the +=.

I found the solution here: http://www.andornot.com/blog/post/The-Uri-gotcha-that-gotchad-me-good.aspx
